### PR TITLE
Fix :setDraggable()

### DIFF
--- a/component.lua
+++ b/component.lua
@@ -100,6 +100,11 @@ function Component:setParent(parent)
 	table.removeByValue(components, self)
 	table.insert(parent.children, self)
 	self.parent = parent
+	
+	if self.type == "dragarea" then
+		self.parent.dragArea = self
+	end	
+	
 	return self
 end
 


### PR DESCRIPTION
`Component:setDraggable` checks for `self.dragArea` which was previously never set when making a parent. It is now declared in `Component:setParent()`.

I think your `:destroy` method should already clear this up, but you know better than me! :grinning: 